### PR TITLE
Exclude nodes based on labels

### DIFF
--- a/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
@@ -48,5 +48,7 @@ spec:
       #      add2:  1,3,5,7 ...
       #      add10: 1,11,21,31 ...
       #      log2:  1,2,4,8,16,32 ,,,
-      # excluded_node: [ worker001 ]
+      # exclude_labels:  (OR conditional, every node that matches any of these labels is excluded)
+      #    - "bad=true"
+      #    - "fc640=true"
 

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -48,10 +48,23 @@
   set_fact:
     worker_node_list: "{{ node_list | json_query('resources[].metadata.name') | list }}"
 
-- name: Exclude unhealthy nodes i.e. low diskspace 
+- name: List Nodes Labeled with {{ workload_args.exclude_label }}
+  k8s_info:
+    api_version: v1
+    kind: Node
+    label_selectors:
+      - '{{ item }}'
+  with_items: "{{ workload_args.exclude_labels }}"
+  register: exclude_node_list
+
+- name: Isolate Worker Role Hostnames for label  {{ workload_args.exclude_label }}
   set_fact:
-      worker_node_list: "{{ worker_node_list | difference(workload_args.excluded_node[0]) }}"
-  when: workload_args.excluded_node is defined and workload_args.excluded_node|length > 0
+    worker_node_exclude_list: "{{ exclude_node_list | json_query('results[].resources[].metadata.name') }}"
+
+- name: Exclude labelled nodes
+  set_fact:
+      worker_node_list: "{{ worker_node_list | difference(worker_node_exclude_list) }}"
+  when: workload_args.exclude_labels is defined and workload_args.exclude_labels | length > 0
 
 - name: A5 Capture ServiceIP
   k8s_facts:


### PR DESCRIPTION
This fits in with the idea that we are viewing worker nodes as just a pool
of resources and not by individual hostnames. This gives the flexibility for
users to isolate the tests to only one hardware model of workers as well (since
each model can be labelled with its model name).

Also there was a bug in previous code where only the first node in the list
was technically being excluded in `workload_args.excluded_node[0]`.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>